### PR TITLE
Handle the case when section obtain form image is null

### DIFF
--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -797,10 +797,10 @@ namespace Mono.Cecil {
 					else
 					{
 						var rsrc = Image.GetSection(".rsrc");
-                        if (rsrc == null)
-                            win32ResourceDirectory = new ResourceDirectory();
-                        else
-						    win32ResourceDirectory = RsrcReader.ReadResourceDirectory(rsrc.Data, rsrc.VirtualAddress);
+						if (rsrc == null)
+							win32ResourceDirectory = new ResourceDirectory();
+						else
+							win32ResourceDirectory = RsrcReader.ReadResourceDirectory(rsrc.Data, rsrc.VirtualAddress);
 					}
 				}
 				return win32ResourceDirectory;


### PR DESCRIPTION
When trying to get the Win32Resources - check if the directory can be ceated from the image
